### PR TITLE
Fixing grisappsd-sensor-simulator

### DIFF
--- a/sensor_simulator.config
+++ b/sensor_simulator.config
@@ -7,7 +7,7 @@
 	"static_args": ["(simulationId)", "(request)","(logLevel)"],
 	"type": "PYTHON",
 	"execution_path": "/gridappsd/services/gridappsd-sensor-simulator/sensor_simulator.py",
-	"launch_on_startup": true,
+	"launch_on_startup": false,
 	"multiple_instances": true,
 	"environmentVariables": [],
 	"user_input": {

--- a/sensor_simulator.py
+++ b/sensor_simulator.py
@@ -93,9 +93,7 @@ if __name__ == '__main__':
     service_id = "gridappsd-sensor-simulator"
     logging.getLogger().info(f"SERVICE ID {service_id}  {feeder}")
     print("SERVICE ID "+str(service_id)+" "+str(feeder))
-    gapp = GridAPPSD(username=opts.username,
-                     password=opts.password,
-                     address=opts.address)
+    gapp = GridAPPSD(address=opts.address)
     
     #gapp.get_logger().setLevel(opts.log_level)
     read_topic = simulation_output_topic(opts.simulation_id)

--- a/sensor_simulator.py
+++ b/sensor_simulator.py
@@ -42,6 +42,7 @@ def get_opts():
                         help="The tcp://addr:port that gridappsd is located on.")
     opts = parser.parse_args()
     opts.log_level = 'DEBUG'
+    logging.getLogger().info(f"OPTS Request: {opts.request}")
 
     if opts.log_level == 'DEBUG':
         opts.log_level = logging.DEBUG
@@ -49,7 +50,7 @@ def get_opts():
         opts.log_level = logging.INFO
     elif opts.log_level == 'ERROR':
         opts.log_level = logging.ERROR
-    elif ops.log_level == 'WARNING' or opts.log_level == 'WARN':
+    elif opts.log_level == 'WARNING' or opts.log_level == 'WARN':
         opts.log_level = logging.WARNING
     elif opts.log_level == 'CRITICAL':
         opts.log_level = logging.CRITICAL

--- a/sensor_simulator.py
+++ b/sensor_simulator.py
@@ -34,10 +34,6 @@ def get_opts():
     # parser.add_argument("--interval", type=float, default=30.0,
     #                     help="Interval in seconds for min, max, average aggregation.")
 
-    #parser.add_argument("-u", "--username", default=utils.get_gridappsd_user(),
-    #                    help="The username to authenticate with the message bus.")
-    #parser.add_argument("-p", "--password", default=utils.get_gridappsd_pass(),
-    #                    help="The password to authenticate with the message bus.")
     parser.add_argument("-a", "--address", default=utils.get_gridappsd_address(),
                         help="The tcp://addr:port that gridappsd is located on.")
     opts = parser.parse_args()
@@ -83,6 +79,7 @@ if __name__ == '__main__':
         if configs['id'] == 'gridappsd-sensor-simulator':
             user_options = configs['user_options']
             break
+        
     feeder = opts.request['power_system_config']['Line_name']
     service_id = "gridappsd-sensor-simulator"
     gapp = GridAPPSD(address=opts.address)
@@ -90,6 +87,7 @@ if __name__ == '__main__':
     #gapp.get_logger().setLevel(opts.log_level)
     read_topic = simulation_output_topic(opts.simulation_id)
     write_topic = service_output_topic(service_id, opts.simulation_id)
+
     log_file = "/tmp/gridappsd_tmp/{}/sensors.log".format(opts.simulation_id)
     if not os.path.exists(os.path.dirname(log_file)):
         os.makedirs(os.path.dirname(log_file))
@@ -100,6 +98,7 @@ if __name__ == '__main__':
 
     meas = Measurements()
     meta = meas.get_sensors_meta(feeder)
+
     with open(log_file, 'w') as fp:
         logging.basicConfig(stream=fp, level=logging.INFO)
         logging.getLogger().info("Almost ready to create sensors!")

--- a/sensor_simulator.py
+++ b/sensor_simulator.py
@@ -42,7 +42,6 @@ def get_opts():
                         help="The tcp://addr:port that gridappsd is located on.")
     opts = parser.parse_args()
     opts.log_level = 'DEBUG'
-    logging.getLogger().info(f"OPTS Request: {opts.request}")
 
     if opts.log_level == 'DEBUG':
         opts.log_level = logging.DEBUG
@@ -59,6 +58,8 @@ def get_opts():
 
     assert opts.request, "request must be passed."
 
+    logging.getLogger().info(f"OPTS Request: {opts.request}")
+    print("OPTS REQUEST "+str(opts.request))
     opts.request = json.loads(opts.request)
 
     return opts

--- a/sensor_simulator.py
+++ b/sensor_simulator.py
@@ -34,10 +34,10 @@ def get_opts():
     # parser.add_argument("--interval", type=float, default=30.0,
     #                     help="Interval in seconds for min, max, average aggregation.")
 
-    parser.add_argument("-u", "--username", default=utils.get_gridappsd_user(),
-                        help="The username to authenticate with the message bus.")
-    parser.add_argument("-p", "--password", default=utils.get_gridappsd_pass(),
-                        help="The password to authenticate with the message bus.")
+    #parser.add_argument("-u", "--username", default=utils.get_gridappsd_user(),
+    #                    help="The username to authenticate with the message bus.")
+    #parser.add_argument("-p", "--password", default=utils.get_gridappsd_pass(),
+    #                    help="The password to authenticate with the message bus.")
     parser.add_argument("-a", "--address", default=utils.get_gridappsd_address(),
                         help="The tcp://addr:port that gridappsd is located on.")
     opts = parser.parse_args()

--- a/sensor_simulator.py
+++ b/sensor_simulator.py
@@ -58,8 +58,6 @@ def get_opts():
 
     assert opts.request, "request must be passed."
 
-    logging.getLogger().info(f"OPTS Request: {opts.request}")
-    print("OPTS REQUEST "+str(opts.request))
     opts.request = json.loads(opts.request)
 
     return opts
@@ -80,26 +78,18 @@ if __name__ == '__main__':
     os.environ['GRIDAPPSD_APPLICATION_STATUS'] = 'STARTED'
     os.environ['GRIDAPPSD_SIMULATION_ID'] = opts.simulation_id
     # find the user_options specifically for sensor-simulator
-    logging.getLogger().info(f"BEFORE SERVICE CONFIGS")
-    print("BEFORE SERVICE CONFIGS ")
     user_options = None
     for configs in opts.request['service_configs']:
         if configs['id'] == 'gridappsd-sensor-simulator':
             user_options = configs['user_options']
             break
-    logging.getLogger().info(f"GOT CONFIGS {user_options}")
-    print("GOT CONFIGS  "+str(user_options))      
     feeder = opts.request['power_system_config']['Line_name']
     service_id = "gridappsd-sensor-simulator"
-    logging.getLogger().info(f"SERVICE ID {service_id}  {feeder}")
-    print("SERVICE ID "+str(service_id)+" "+str(feeder))
     gapp = GridAPPSD(address=opts.address)
     
     #gapp.get_logger().setLevel(opts.log_level)
     read_topic = simulation_output_topic(opts.simulation_id)
     write_topic = service_output_topic(service_id, opts.simulation_id)
-    logging.getLogger().info(f"AFTER TOPICS")
-    print(" AFTER TOPICS")
     log_file = "/tmp/gridappsd_tmp/{}/sensors.log".format(opts.simulation_id)
     if not os.path.exists(os.path.dirname(log_file)):
         os.makedirs(os.path.dirname(log_file))
@@ -108,12 +98,8 @@ if __name__ == '__main__':
     from pprint import pprint
     from sensors.measurements import Measurements
 
-    logging.getLogger().info(f"BEFORE MEAS")
-    print("BEFORE MEAS ")
     meas = Measurements()
     meta = meas.get_sensors_meta(feeder)
-    logging.getLogger().info(f"AFTER MEAS")
-    print("AFTER MEAS ")
     with open(log_file, 'w') as fp:
         logging.basicConfig(stream=fp, level=logging.INFO)
         logging.getLogger().info("Almost ready to create sensors!")
@@ -122,6 +108,4 @@ if __name__ == '__main__':
         logging.getLogger().debug(f"Meta: {meta}")
         run_sensors = Sensors(gapp, read_topic=read_topic, write_topic=write_topic,
                               user_options=user_options, measurements=meta)
-        logging.getLogger().info(f"RUNNING MAIN LOOP")
-        print("RUNNING MAIN LOOP ")
         run_sensors.main_loop()

--- a/sensor_simulator.py
+++ b/sensor_simulator.py
@@ -80,15 +80,19 @@ if __name__ == '__main__':
     os.environ['GRIDAPPSD_APPLICATION_STATUS'] = 'STARTED'
     os.environ['GRIDAPPSD_SIMULATION_ID'] = opts.simulation_id
     # find the user_options specifically for sensor-simulator
+    logging.getLogger().info(f"BEFORE SERVICE CONFIGS")
+    print("BEFORE SERVICE CONFIGS ")
     user_options = None
     for configs in opts.request['service_configs']:
         if configs['id'] == 'gridappsd-sensor-simulator':
             user_options = configs['user_options']
             break
-      
+    logging.getLogger().info(f"GOT CONFIGS {user_options}")
+    print("GOT CONFIGS  "+str(user_options))      
     feeder = opts.request['power_system_config']['Line_name']
     service_id = "gridappsd-sensor-simulator"
-
+    logging.getLogger().info(f"SERVICE ID {service_id}  {feeder}")
+    print("SERVICE ID "+str(service_id)+" "+str(feeder))
     gapp = GridAPPSD(username=opts.username,
                      password=opts.password,
                      address=opts.address)
@@ -96,7 +100,8 @@ if __name__ == '__main__':
     #gapp.get_logger().setLevel(opts.log_level)
     read_topic = simulation_output_topic(opts.simulation_id)
     write_topic = service_output_topic(service_id, opts.simulation_id)
-
+    logging.getLogger().info(f"AFTER TOPICS")
+    print(" AFTER TOPICS")
     log_file = "/tmp/gridappsd_tmp/{}/sensors.log".format(opts.simulation_id)
     if not os.path.exists(os.path.dirname(log_file)):
         os.makedirs(os.path.dirname(log_file))
@@ -105,9 +110,12 @@ if __name__ == '__main__':
     from pprint import pprint
     from sensors.measurements import Measurements
 
+    logging.getLogger().info(f"BEFORE MEAS")
+    print("BEFORE MEAS ")
     meas = Measurements()
     meta = meas.get_sensors_meta(feeder)
-    
+    logging.getLogger().info(f"AFTER MEAS")
+    print("AFTER MEAS ")
     with open(log_file, 'w') as fp:
         logging.basicConfig(stream=fp, level=logging.INFO)
         logging.getLogger().info("Almost ready to create sensors!")
@@ -116,4 +124,6 @@ if __name__ == '__main__':
         logging.getLogger().debug(f"Meta: {meta}")
         run_sensors = Sensors(gapp, read_topic=read_topic, write_topic=write_topic,
                               user_options=user_options, measurements=meta)
+        logging.getLogger().info(f"RUNNING MAIN LOOP")
+        print("RUNNING MAIN LOOP ")
         run_sensors.main_loop()

--- a/sensor_simulator.py
+++ b/sensor_simulator.py
@@ -79,7 +79,7 @@ if __name__ == '__main__':
         if configs['id'] == 'gridappsd-sensor-simulator':
             user_options = configs['user_options']
             break
-        
+
     feeder = opts.request['power_system_config']['Line_name']
     service_id = "gridappsd-sensor-simulator"
     gapp = GridAPPSD(address=opts.address)
@@ -98,7 +98,7 @@ if __name__ == '__main__':
 
     meas = Measurements()
     meta = meas.get_sensors_meta(feeder)
-
+    
     with open(log_file, 'w') as fp:
         logging.basicConfig(stream=fp, level=logging.INFO)
         logging.getLogger().info("Almost ready to create sensors!")


### PR DESCRIPTION
The service was no longer starting because the gridappsd library changed so that it expects the username and password to come from environment variables rather than parameters.  It is also a simulation based service and should only be run on simulation, not on startup